### PR TITLE
濁音・半濁音の半角カナを入力すると文字化けする問題の修正

### DIFF
--- a/EmojicaTests/EmojicaTests.swift
+++ b/EmojicaTests/EmojicaTests.swift
@@ -21,8 +21,11 @@
 //
 
 import XCTest
+import Emojica
 
 class EmojicaTests: XCTestCase {
+    
+    let emojica = Emojica()
     
     override func setUp() {
         super.setUp()
@@ -37,6 +40,39 @@ class EmojicaTests: XCTestCase {
     func testExample() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testConvert() {
+        XCTContext.runActivity(named: "Half-width characters") { _ in
+            let inputText: String = "Sample text 😎"
+            let converted: NSAttributedString = emojica.convert(string: inputText)
+            XCTAssertEqual(inputText, converted.string)
+        }
+        XCTContext.runActivity(named: "Hiragana") { _ in
+            let inputText: String = "さんぷる　てきすと 😎"
+            let converted: NSAttributedString = emojica.convert(string: inputText)
+            XCTAssertEqual(inputText, converted.string)
+        }
+        XCTContext.runActivity(named: "Katakana") { _ in
+            let inputText: String = "サンプル　テキスト 😎"
+            let converted: NSAttributedString = emojica.convert(string: inputText)
+            XCTAssertEqual(inputText, converted.string)
+        }
+        XCTContext.runActivity(named: "Harf-wide Katakana") { _ in
+            let inputText: String = "ｻﾝﾌﾟﾙ ﾃｷｽﾄ 😎"
+            let converted: NSAttributedString = emojica.convert(string: inputText)
+            XCTAssertEqual(inputText, converted.string)
+        }
+        XCTContext.runActivity(named: "Kanji") { _ in
+            let inputText: String = "例文 😎"
+            let converted: NSAttributedString = emojica.convert(string: inputText)
+            XCTAssertEqual(inputText, converted.string)
+        }
+        XCTContext.runActivity(named: "concatenation") { _ in
+            let inputText: String = "ǟæ 😎"
+            let converted: NSAttributedString = emojica.convert(string: inputText)
+            XCTAssertEqual(inputText, converted.string)
+        }
     }
     
     func testPerformanceExample() {

--- a/Source/Emojica.swift
+++ b/Source/Emojica.swift
@@ -211,9 +211,9 @@ extension Emojica {
                 
                 if unicodeScalarStack.isEmpty {
                     
-                    // Quit iterating if stack is empty and current scalar isn't emoji.
-                    guard unicodeScalar.isEmoji else { break }
-                    unicodeScalarStack.push(unicodeScalar)
+                    if unicodeScalar.isEmoji {
+                        unicodeScalarStack.push(unicodeScalar)
+                    }
                     
                 } else {
                     


### PR DESCRIPTION
~~濁音・半濁音がある半角カナは合成文字となっている。
例：「プ」は「フ」と「゜」の合成
期待値としては、「フ」と「゜」がそれぞれ判定されることだったが、「フ」の部分でbreakされてしまい、「゜」の部分の処理が行われず、文字化けが発生していました。（文字コードが一部欠けた状態？になってしまう）~~

絵文字を置換するところで正しいRangeではないもので置換処理が行われることで文字化けが起きてしまう。
合成文字だと1文字目でbreakしてしまうので、絵文字を置換するRangeの値が正しいものではなくなる。
（UnicodeScalarのサイズ分Rangeがズレてしまう）

breakしないようにすることでRangeがズレてしまう問題を解決しました。
