### PR TITLE
Bundleを指定して画像を読み込めるように対応

### DIFF
--- a/Emojica.xcodeproj/project.pbxproj
+++ b/Emojica.xcodeproj/project.pbxproj
@@ -296,7 +296,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -353,7 +353,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -375,7 +375,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xoudini.Emojica;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -396,7 +396,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xoudini.Emojica;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -415,7 +415,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = EmojicaTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xoudini.EmojicaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -434,7 +434,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = EmojicaTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xoudini.EmojicaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Source/Emojica.swift
+++ b/Source/Emojica.swift
@@ -108,6 +108,11 @@ public final class Emojica : NSObject {
     
     /// Keep the instance non-revertible if the original strings aren't needed after conversion.
     public var revertible: Bool = false
+    
+    
+    /// The bundle containing the image file.
+    /// - Note: Specify nil to search the app’s main bundle.
+    public var imageBundle: Bundle?
 }
 
 extension Emojica {
@@ -281,7 +286,7 @@ extension Emojica {
                 .joined(separator: self.separator)
         }
         
-        guard let image = UIImage(named: name) else { return nil }
+        guard let image = UIImage(named: name, in: imageBundle, with: nil) else { return nil }
         
         let attachment = EmojicaAttachment()
         attachment.image = image
@@ -311,7 +316,7 @@ extension Emojica {
             
             let name = String(format: self.formatString, unicodeScalar.value)
             
-            if let image = UIImage(named: name) {
+            if let image = UIImage(named: name, in: imageBundle, with: nil) {
                 
                 let attachment = EmojicaAttachment()
                 attachment.image = image


### PR DESCRIPTION
Bundleを指定して画像を読み込めるように対応しました。
UIImageの`init(named:in:with:)`を用いる必要があるのでターゲットバージョンを13.0以上に変更しています。

参考
https://developer.apple.com/documentation/uikit/uiimage/3294226-init